### PR TITLE
Fix onset time in [0, 12] hours assigned to incorrect date

### DIFF
--- a/src/actigraphy/database/utils.py
+++ b/src/actigraphy/database/utils.py
@@ -78,6 +78,9 @@ def initialize_ms4_sleep_times(
     )
     onset_time = timestamp2datetime(onset, day, utc_offset)
     wakeup_time = timestamp2datetime(wakeup, day, utc_offset)
+
+    if onset_time.hour < 12:  # noqa: PLR2004
+        onset_time += datetime.timedelta(days=1)
     if onset_time > wakeup_time:
         wakeup_time += datetime.timedelta(days=1)
 


### PR DESCRIPTION
This pull request fixes an issue where the onset time in the range of [0, 12] hours was being assigned to the incorrect date. The problem was resolved by adding a condition to increment the onset time by one day if it falls before 12 hours.

Partially addresses #45